### PR TITLE
Add Dockerfile for ECX cross-compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    wget \
+    unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install ECX Amiga E cross-compiler
+ARG ECX_VERSION=3.3.0
+RUN wget -q https://github.com/jj1bdx/ecx/releases/download/v${ECX_VERSION}/ecx_${ECX_VERSION}_linux.zip \
+    && unzip ecx_${ECX_VERSION}_linux.zip -d /opt/ecx \
+    && rm ecx_${ECX_VERSION}_linux.zip
+
+ENV PATH="/opt/ecx:${PATH}"
+
+WORKDIR /src
+COPY mandelbrot.e /src/
+
+CMD ["ecx", "mandelbrot.e", "-o", "Mandelbrot"]

--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ ec mandelbrot.e -o Mandelbrot
 Run the resulting executable on an AGA-capable AmigaOS 3.1 machine. Drag with the left
 mouse button to select an area and zoom. Press `s` to save the current view to
 `mandel.iff` or press `Esc` or any other mouse button to exit.
+
+### Build with Docker
+
+To compile using the [ECX](https://github.com/jj1bdx/ecx) cross-compiler inside Docker:
+
+```
+docker build -t mandelbrot-e .
+docker run --rm -v "$PWD:/src" mandelbrot-e
+```
+
+The resulting `Mandelbrot` binary will be written to the repository directory and can be
+copied to an AmigaOS 3.1 system.


### PR DESCRIPTION
## Summary
- Add Dockerfile that installs ECX Amiga E cross-compiler and builds the Mandelbrot example
- Document Docker-based build process in README

## Testing
- `ec mandelbrot.e -o Mandelbrot` *(fails: command not found)*
- `docker build -t mandelbrot-e .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf88cf0d08333a3f3e2720f7c491a